### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy to Fly.io
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/azeiteiro/burro_dos_concertos/security/code-scanning/1](https://github.com/azeiteiro/burro_dos_concertos/security/code-scanning/1)

In general, to fix this kind of issue you must explicitly define the `permissions:` for the GITHUB_TOKEN at either the workflow root or per job, granting only what is needed (typically `contents: read` as a safe baseline) instead of relying on repository defaults.

For this specific workflow, neither `test` nor `deploy` actually need to modify the GitHub repository or issues, they just check out code, install dependencies, run tests, and deploy using an external Fly.io token. So we can safely set `permissions: contents: read` at the top level of the workflow, applying to all jobs, without changing any functionality. This aligns with the “minimal starting point” recommended by CodeQL and GitHub. The change should be made near the top of `.github/workflows/deploy.yml`, after the `name:` (line 1) and before or after the `on:` block; both positions are valid in GitHub Actions syntax, but placing it after `name:` and before `on:` makes it prominent. No additional imports, methods, or definitions are required since this is just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
