### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/azeiteiro/burro_dos_concertos/security/code-scanning/2](https://github.com/azeiteiro/burro_dos_concertos/security/code-scanning/2)

In general, fix this by explicitly setting a `permissions` block for the workflow (or for the specific job) so that `GITHUB_TOKEN` has the least privileges needed. For a typical CI workflow that just checks out code and uploads coverage to a third-party service, `contents: read` is usually sufficient; no write access is required.

The best minimal change here is to add a top-level `permissions` block right after the `name: CI` line in `.github/workflows/ci.yml`, setting `contents: read`. This will apply to all jobs in the workflow (currently just `build`) and constrain the automatically provided `GITHUB_TOKEN` to read-only repository contents, while still allowing checkout and Coveralls to function. No changes to individual steps, actions, or environment variables are required, and existing functionality (linting, tests, and coverage upload) should remain intact.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  after line 1 (`name: CI`) and before the `on:` block.
- No new imports, methods, or other definitions are needed, as this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
