### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete string escaping or encoding

### DIFF
--- a/src/notifications/helpers.ts
+++ b/src/notifications/helpers.ts
@@ -16,7 +16,7 @@ if (!getGroupId()) {
 
 // Escape Markdown special characters to prevent formatting issues
 const escapeMarkdown = (text: string): string => {
-  return text.replace(/([_*[\]()~`>#+=|{}.!-])/g, "\\$1");
+  return text.replace(/([_*[\]()~`>#+=|{}.!\-\\])/g, "\\$1");
 };
 
 export const formatConcertList = (title: string, concerts: Concert[]) => {


### PR DESCRIPTION
Potential fix for [https://github.com/azeiteiro/burro_dos_concertos/security/code-scanning/5](https://github.com/azeiteiro/burro_dos_concertos/security/code-scanning/5)

In general, to fix incomplete escaping you must include backslash in the set of characters being escaped, and ensure the replacement logic handles it consistently for all occurrences. For this function, the best fix is to update the regular expression so that it matches `\` in addition to the existing Markdown meta-characters, and escapes it with a leading backslash in the replacement. Because `.replace(/.../g, "\\$1")` already prepends a backslash to the matched character, we only need to add `\` to the character class.

Concretely, in `src/notifications/helpers.ts`, update the `escapeMarkdown` implementation at line 19 so that the character class includes backslash. The new regex should read `/([_*[\]()~`>#+=|{}.!\-\\])/g` (order inside the class doesn’t matter, but we must properly escape `-` and `\` inside the character class). No new imports or additional functions are needed; this is a localized change to the single helper function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
