### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/src/services/linkAnalyzer.ts
+++ b/src/services/linkAnalyzer.ts
@@ -204,7 +204,13 @@ async function browserlessFetch(url: string): Promise<{ body: string; url: strin
     const finalUrl = page.url();
 
     // Check if we've been redirected to Queue-it (bot protection)
-    if (finalUrl.includes("queue-it.net")) {
+    let queueItHost = "";
+    try {
+      queueItHost = new URL(finalUrl).hostname.toLowerCase();
+    } catch {
+      queueItHost = "";
+    }
+    if (queueItHost === "queue-it.net" || queueItHost.endsWith(".queue-it.net")) {
       console.warn(
         `⚠️ Detected Queue-it bot protection on ${url}. Cannot extract metadata due to anti-bot measures.`
       );


### PR DESCRIPTION
Potential fix for [https://github.com/azeiteiro/burro_dos_concertos/security/code-scanning/8](https://github.com/azeiteiro/burro_dos_concertos/security/code-scanning/8)

In general, the problem is that we are checking for `queue-it.net` anywhere in the full URL string instead of examining the parsed hostname. The fix is to parse `finalUrl` as a URL and inspect its `hostname` (or `host`) property, then compare that value against what we consider to be Queue-it domains (e.g., `queue-it.net` or specific subdomains). This aligns with the recommendation: never treat the whole URL as a string for host checks.

The best fix here, while preserving existing behavior as much as possible, is:

1. Parse `finalUrl` using the standard `URL` class available in Node.js and modern browsers; this does not require adding any external dependencies or changing current imports.
2. Extract the hostname, normalize it to lowercase, and then check if it equals `queue-it.net` or ends with `.queue-it.net`. This covers the main domain and any subdomains while avoiding false positives such as `evil-queue-it.net` or query-string/path matches.
3. Replace `if (finalUrl.includes("queue-it.net"))` with a new condition that uses the parsed hostname as described.

This change is localized to the region around line 207 in `src/services/linkAnalyzer.ts`. No new helper functions or imports are strictly needed because `URL` is globally available in TypeScript/Node, but using it explicitly in the condition keeps the change minimal and clear.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
